### PR TITLE
make changesets a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,11 @@
       "plugins/**"
     ]
   },
-  "dependencies": {
-    "@changesets/cli": "^2.18.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@backstage/cli": "^0.22.3",
     "@spotify/prettier-config": "^12.0.0",
+    "@changesets/cli": "^2.18.0",
     "@types/webpack": "^5.28.0",
     "concurrently": "^7.0.0",
     "husky": "^8.0.0",


### PR DESCRIPTION
One of the dependencies of the changesets package contains a GPL license which is more restrictive than the MIT licences. By making it a dev dependency it makes this plugin more acessible for use.

Im hoping there was not a good reason that it was a top level dependency in the first place.