### PR TITLE
Add missing createPermissionIntegrationRouter call

### DIFF
--- a/.changeset/selfish-boxes-itch.md
+++ b/.changeset/selfish-boxes-itch.md
@@ -1,0 +1,5 @@
+---
+'@k-phoen/backstage-plugin-announcements-backend': minor
+---
+
+Exposes the announcements plugin's permissions in a metadata endpoint

--- a/plugins/announcements-backend/src/service/router.ts
+++ b/plugins/announcements-backend/src/service/router.ts
@@ -13,9 +13,11 @@ import {
 import {
   announcementCreatePermission,
   announcementDeletePermission,
+  announcementEntityPermissions,
   announcementUpdatePermission,
 } from '@k-phoen/backstage-plugin-announcements-common';
 import { AnnouncementsContext } from './announcementsContextBuilder';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 
 interface AnnouncementRequest {
   publisher: string;
@@ -33,6 +35,10 @@ export async function createRouter(
   options: AnnouncementsContext,
 ): Promise<express.Router> {
   const { persistenceContext, permissions } = options;
+
+  const permissionIntegrationRouter = createPermissionIntegrationRouter({
+    permissions: Object.values(announcementEntityPermissions),
+  });
 
   const isRequestAuthorized = async (
     req: Request,
@@ -53,6 +59,7 @@ export async function createRouter(
 
   const router = Router();
   router.use(express.json());
+  router.use(permissionIntegrationRouter);
 
   // eslint-disable-next-line spaced-comment
   /*****************


### PR DESCRIPTION
We (the permission framework maintainers) updated the correct usage of createPermissionIntegrationRouter, but the docs remained outdated. As part of fixing the docs (https://github.com/backstage/backstage/pull/17388) we're making PRs to help fix the issue in community plugins as well.