### PR TITLE
Fix AnnouncementCollatorApi to call correct endpoint

### DIFF
--- a/plugins/announcements-backend/src/search/api.ts
+++ b/plugins/announcements-backend/src/search/api.ts
@@ -11,6 +11,11 @@ export type Announcement = {
   created_at: string;
 };
 
+export type AnnouncementsList = {
+    count: number;
+    results: Announcement[];
+};
+
 export class AnnouncementsClient {
   private readonly discoveryApi: DiscoveryApi;
 
@@ -30,6 +35,7 @@ export class AnnouncementsClient {
   }
 
   async announcements(): Promise<Announcement[]> {
-    return await this.fetch<Announcement[]>('/');
+    const result = await this.fetch<AnnouncementsList>('/announcements');
+    return result?.results;
   }
 }


### PR DESCRIPTION
See [Issue #177](https://github.com/K-Phoen/backstage-plugin-announcements/issues/177). 

The API is calling an endpoint that doesn't exist, so I fix the endpoint and handle the result