### PR TITLE
fix: use backstage fetch api instead of the default fetch for node js

### DIFF
--- a/.changeset/dry-pens-hope.md
+++ b/.changeset/dry-pens-hope.md
@@ -1,0 +1,5 @@
+---
+'@k-phoen/backstage-plugin-announcements': patch
+---
+
+Use backstage fetch API

--- a/plugins/announcements/src/plugin.ts
+++ b/plugins/announcements/src/plugin.ts
@@ -6,6 +6,7 @@ import {
   discoveryApiRef,
   errorApiRef,
   identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import {
   createSearchResultListItemExtension,
@@ -27,12 +28,14 @@ export const announcementsPlugin = createPlugin({
         discoveryApi: discoveryApiRef,
         identityApi: identityApiRef,
         errorApi: errorApiRef,
+        fetchApi: fetchApiRef,
       },
-      factory: ({ discoveryApi, identityApi, errorApi }) => {
+      factory: ({ discoveryApi, identityApi, errorApi, fetchApi }) => {
         return new DefaultAnnouncementsApi({
           discoveryApi: discoveryApi,
           identityApi: identityApi,
           errorApi: errorApi,
+          fetchApi: fetchApi,
         });
       },
     }),


### PR DESCRIPTION
# Context
Backstage provides a FetchApi to make requests this allows backstage users to create fetch customizations like automatic header 
injections. This Pr modifies the announcements plugin to use the backstage fetch api, making it compatible with any backstage implementation using any fetch api customization.

# Changes
- Loads the fetch api when creating the api factory for the announcements api
- Uses the fetch api in the default fetch api implementation

# Additional Comments
The request object was removed as it was causing problems with the fetch api from backstage, the parameters were passed directly to the fetch call instead

```ts
const request = new Request(`${baseApiUrl}${input}`, {
      ...init,
      headers,
    });
```

# Reference
Fetch Api Reference: https://backstage.io/docs/reference/core-plugin-api.fetchapi/

