### PR TITLE
Allow choosing z-index of the new announcement banner

### DIFF
--- a/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -8,20 +8,21 @@ import {
   makeStyles,
   Snackbar,
   SnackbarContent,
+  Theme,
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import Close from '@material-ui/icons/Close';
 import { Announcement, announcementsApiRef } from '../../api';
 import { announcementViewRouteRef } from '../../routes';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<Theme, AnnouncementBannerProps>(theme => ({
   // showing on top, as a block
   blockPositioning: {
     padding: theme.spacing(0),
     position: 'relative',
     marginBottom: theme.spacing(4),
     marginTop: -theme.spacing(3),
-    zIndex: 'unset',
+    zIndex: props => (props.retainZIndex ? theme.zIndex.snackbar : 'unset'),
   },
   // showing on top, as a floating alert
   floatingPositioning: {},
@@ -49,10 +50,11 @@ const useStyles = makeStyles(theme => ({
 type AnnouncementBannerProps = {
   announcement: Announcement;
   variant?: 'block' | 'floating';
+  retainZIndex?: boolean;
 };
 
 const AnnouncementBanner = (props: AnnouncementBannerProps) => {
-  const classes = useStyles();
+  const classes = useStyles(props);
   const announcementsApi = useApi(announcementsApiRef);
   const viewAnnouncementLink = useRouteRef(announcementViewRouteRef);
   const [bannerOpen, setBannerOpen] = useState(true);


### PR DESCRIPTION
Add a `retainZIndex` property to `NewAnnouncementBanner` to allow preserving the z-index of the announcement bar. The previous default was to set `zIndex: unset` which causes some issues where the banner is below the other text on the page. The new property is faulse by default so this will have no effect on existing users. 